### PR TITLE
Add facility to support board exports, starting with GraphViz

### DIFF
--- a/addons/puzzle_dependencies/components/settings.gd
+++ b/addons/puzzle_dependencies/components/settings.gd
@@ -20,6 +20,7 @@ func _ready() -> void:
 		config.set_value("boards", "minimap_size", Vector2(200, 150))
 		config.set_value("boards", "use_snap", true)
 		config.set_value("boards", "snap_distance", 20)
+		config.set_value("boards", "export_save_location", "res://")
 	
 	yield(get_parent(), "ready")
 	if not config.has_section("types"):

--- a/addons/puzzle_dependencies/export_formats/graphviz.gd
+++ b/addons/puzzle_dependencies/export_formats/graphviz.gd
@@ -57,6 +57,7 @@ func _find_type_by_id(types: Array, id: int):
 
 
 func _save_to_disk(text: String, path: String, filename: String) -> bool:
+	print(path)
 	if not path.ends_with("/"):
 		path += "/"
 

--- a/addons/puzzle_dependencies/export_formats/graphviz.gd
+++ b/addons/puzzle_dependencies/export_formats/graphviz.gd
@@ -1,0 +1,73 @@
+tool
+extends Node
+
+
+# data: An array of dictionaries containing information about any boards to be exported.
+# types: An array of dictionaries containing all information about thing types.
+# save_location: Location to which the exports should be saved.
+func save_to_format(data: Array, types: Array, save_location: String) -> bool:
+	var result: bool = false
+
+	for board in data:
+		var graphviz_string: String = "strict graph {\n"
+
+		# Nodes
+		for thing in board["things"]:
+			# Instead of calling out to the settings, we make do with passing in
+			# the type information.
+			var type = _find_type_by_id(types, thing["type"])
+			
+			# TODO: Somehow tie these defaults back to what they actually are
+			# since "type 0" isn't stored in the config file.
+			var fill_color: Color = Color.black
+			var font_color: Color = Color.white
+
+			if type:
+				fill_color = type.color
+				font_color = Color.black if fill_color.v > 0.5 else Color.white
+
+			graphviz_string += "\"%s\" [label=\"%s\", shape=%s, style=%s, fillcolor=\"#%s\", fontcolor=\"#%s\"]\n" \
+				% [
+					thing["id"], 
+					thing["text"],
+					"Mrecord",
+					"filled",
+					fill_color.to_html(false),
+					font_color.to_html(false)
+				]
+
+		# Edges
+		for connection in board["connections"]:
+			graphviz_string += "\"%s\" -- \"%s\"\n" % [connection["from"], connection["to"]]
+
+		graphviz_string += "}"
+
+		# For now, if the last save fails, we return false, but this can be reconsidered.
+		result = _save_to_disk(graphviz_string, save_location, board["label"])
+
+	return result
+
+
+func _find_type_by_id(types: Array, id: int):
+	for type in types:
+		if type.id == id:
+			return type
+
+	return null
+
+
+func _save_to_disk(text: String, path: String, filename: String) -> bool:
+	if not path.ends_with("/"):
+		path += "/"
+
+	var out_file := File.new()
+	var res = out_file.open("%s%s.dot" % [path, filename], File.WRITE)
+
+	if res != OK:
+		print("Error opening DOT file for writing.")
+		return false
+
+	out_file.store_string(text)
+	out_file.close()
+
+	return true

--- a/addons/puzzle_dependencies/views/export_dialog.gd
+++ b/addons/puzzle_dependencies/views/export_dialog.gd
@@ -1,0 +1,112 @@
+tool
+extends WindowDialog
+
+
+signal export_done(save_path)
+
+
+# Store for use in exporting.
+var _types: Array = []
+
+
+onready var export_formats := $ExportFormats
+onready var board_list := $Margin/VBox/Boards
+onready var format_list := $Margin/VBox/Formats
+onready var export_save_location := $Margin/VBox/SaveLocation
+onready var boards_alert := $BoardsAcceptDialog
+onready var format_alert := $FormatAcceptDialog
+onready var export_finished_alert := $ExportAcceptDialog
+onready var location_does_not_exist_alert := $LocationDoesNotExistAcceptDialog
+
+
+func export_boards(boards: Dictionary, current_board_id: String, types: Array, save_location: String) -> void:
+	export_save_location.text = save_location
+	_types = types
+
+	populate_board_list(boards, current_board_id)
+
+	populate_format_list()
+	
+	popup_centered()
+
+
+func populate_board_list(boards: Dictionary, current_board_id: String) -> void:
+	board_list.clear()
+	
+	var board_index_to_select: int = -1
+
+	for board in boards:
+		board_list.add_item(boards[board]["label"])
+		board_list.set_item_metadata(board_list.get_item_count() - 1, boards[board])
+
+	board_list.sort_items_by_text()
+
+	for board_idx in range(0, board_list.get_item_count()):
+		if board_list.get_item_metadata(board_idx)["id"] == current_board_id:
+			board_list.select(board_idx)
+			break
+
+	board_list.ensure_current_is_visible()
+
+
+func populate_format_list() -> void:
+	format_list.clear()
+
+	for option in export_formats.get_children():
+		format_list.add_item(option.get_name())
+		format_list.set_item_metadata(format_list.get_item_count() - 1, option)
+
+
+func _on_DoneButton_pressed() -> void:
+	hide()
+
+
+func _on_ExportButton_pressed() -> void:
+	if format_list.get_selected_id() == -1:
+		format_alert.popup_centered()
+		return
+
+	var selected_items: PoolIntArray = board_list.get_selected_items()
+
+	if selected_items.empty():
+		boards_alert.popup_centered()
+		return
+
+	for idx in selected_items:
+		var data: Dictionary = board_list.get_item_metadata(idx)
+
+		_export_to_format(data, format_list.get_selected_metadata())
+
+
+# TODO: Add in export options object to pass on.
+func _export_to_format(data: Dictionary, format: Node) -> void:
+	if not _validate_location(export_save_location.text):
+		return
+
+	if format.has_method("save_to_format"):
+		var result: bool = format.save_to_format([data], _types, export_save_location.text)
+
+		if result:
+			export_finished_alert.dialog_text = "Board(s) exported successfully!"
+
+		else:
+			export_finished_alert.dialog_text = "One or more boards were unable to be exported."
+
+		# Signal done with the save location as we currently don't track how many successes vs
+		# failures for exports there were (other than "all" or "not all").
+		emit_signal("export_done", export_save_location.text)
+
+		export_finished_alert.popup_centered()
+	else:
+		print("Export format node '%s' has no 'save_to_format' method!" % format.get_name())
+
+
+func _validate_location(location: String) -> bool:
+	# For now, assume we're only saving locally to disk.
+	var dir: Directory = Directory.new()
+
+	if not dir.dir_exists(location):
+		location_does_not_exist_alert.popup_centered()
+		return false
+
+	return true

--- a/addons/puzzle_dependencies/views/export_dialog.tscn
+++ b/addons/puzzle_dependencies/views/export_dialog.tscn
@@ -55,15 +55,23 @@ text = "Export format:"
 margin_right = 29.0
 margin_bottom = 20.0
 
-[node name="Label3" type="Label" parent="Margin/VBox"]
+[node name="HBox" type="HBoxContainer" parent="Margin/VBox"]
 margin_right = 40.0
+margin_bottom = 40.0
+
+[node name="Label3" type="Label" parent="Margin/VBox/HBox"]
+margin_right = 50.0
 margin_bottom = 14.0
 text = "Save to:"
 
-[node name="SaveLocation" type="LineEdit" parent="Margin/VBox"]
+[node name="SaveLocation" type="LineEdit" parent="Margin/VBox/HBox"]
 margin_right = 333.0
 margin_bottom = 203.0
-text = "res://"
+size_flags_horizontal = 3
+
+[node name="SaveLocationButton" type="ToolButton" parent="Margin/VBox/HBox"]
+margin_right = 12.0
+margin_bottom = 22.0
 
 [node name="Center" type="CenterContainer" parent="Margin/VBox"]
 margin_right = 40.0
@@ -114,5 +122,17 @@ popup_exclusive = true
 window_title = "Location Not Found"
 dialog_text = "Please ensure that the save location actually exists."
 
+[node name="ExportFileDialog" type="FileDialog" parent="."]
+margin_right = 315.0
+margin_bottom = 130.0
+rect_min_size = Vector2( 350, 550 )
+size_flags_horizontal = 3
+size_flags_vertical = 3
+window_title = "Open a Directory"
+dialog_hide_on_ok = true
+mode = 2
+
+[connection signal="pressed" from="Margin/VBox/HBox/SaveLocationButton" to="." method="_on_SaveLocationButton_pressed"]
 [connection signal="pressed" from="Margin/VBox/Center/HBox/ExportButton" to="." method="_on_ExportButton_pressed"]
 [connection signal="pressed" from="Margin/VBox/Center/HBox/DoneButton" to="." method="_on_DoneButton_pressed"]
+[connection signal="dir_selected" from="ExportFileDialog" to="." method="_on_ExportFileDialog_dir_selected"]

--- a/addons/puzzle_dependencies/views/export_dialog.tscn
+++ b/addons/puzzle_dependencies/views/export_dialog.tscn
@@ -1,0 +1,118 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://addons/puzzle_dependencies/views/export_dialog.gd" type="Script" id=1]
+[ext_resource path="res://addons/puzzle_dependencies/export_formats/graphviz.gd" type="Script" id=2]
+
+[node name="ExportDialog" type="WindowDialog"]
+margin_right = 353.0
+margin_bottom = 263.0
+window_title = "Export"
+script = ExtResource( 1 )
+
+[node name="ExportFormats" type="Node" parent="."]
+
+[node name="GraphViz" type="Node" parent="ExportFormats"]
+script = ExtResource( 2 )
+
+[node name="Margin" type="MarginContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_constants/margin_right = 10
+custom_constants/margin_top = 10
+custom_constants/margin_left = 10
+custom_constants/margin_bottom = 10
+
+[node name="VBox" type="VBoxContainer" parent="Margin"]
+margin_left = 10.0
+margin_top = 10.0
+margin_right = 343.0
+margin_bottom = 253.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Label" type="Label" parent="Margin/VBox"]
+margin_right = 160.0
+margin_bottom = 14.0
+text = "Select board(s) to export:"
+
+[node name="Boards" type="ItemList" parent="Margin/VBox"]
+margin_top = 18.0
+margin_right = 160.0
+margin_bottom = 18.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+select_mode = 1
+allow_reselect = true
+
+[node name="Label2" type="Label" parent="Margin/VBox"]
+margin_right = 40.0
+margin_bottom = 14.0
+text = "Export format:"
+
+[node name="Formats" type="OptionButton" parent="Margin/VBox"]
+margin_right = 29.0
+margin_bottom = 20.0
+
+[node name="Label3" type="Label" parent="Margin/VBox"]
+margin_right = 40.0
+margin_bottom = 14.0
+text = "Save to:"
+
+[node name="SaveLocation" type="LineEdit" parent="Margin/VBox"]
+margin_right = 333.0
+margin_bottom = 203.0
+text = "res://"
+
+[node name="Center" type="CenterContainer" parent="Margin/VBox"]
+margin_right = 40.0
+margin_bottom = 40.0
+
+[node name="HBox" type="HBoxContainer" parent="Margin/VBox/Center"]
+margin_top = 10.0
+margin_right = 102.0
+margin_bottom = 30.0
+
+[node name="ExportButton" type="Button" parent="Margin/VBox/Center/HBox"]
+margin_right = 12.0
+margin_bottom = 20.0
+text = "Export"
+
+[node name="DoneButton" type="Button" parent="Margin/VBox/Center/HBox"]
+margin_left = -23.0
+margin_top = -10.0
+margin_right = 23.0
+margin_bottom = 10.0
+text = "Done"
+
+[node name="BoardsAcceptDialog" type="AcceptDialog" parent="."]
+margin_right = 83.0
+margin_bottom = 58.0
+popup_exclusive = true
+window_title = "No Board(s) Selected"
+dialog_text = "Please select at least one board to export."
+
+[node name="FormatAcceptDialog" type="AcceptDialog" parent="."]
+margin_right = 83.0
+margin_bottom = 58.0
+popup_exclusive = true
+window_title = "No Format Selected"
+dialog_text = "Please select an export format."
+
+[node name="ExportAcceptDialog" type="AcceptDialog" parent="."]
+margin_right = 83.0
+margin_bottom = 58.0
+popup_exclusive = true
+window_title = "Export Finished"
+dialog_text = "Board(s) exported!"
+
+[node name="LocationDoesNotExistAcceptDialog" type="AcceptDialog" parent="."]
+margin_right = 83.0
+margin_bottom = 58.0
+popup_exclusive = true
+window_title = "Location Not Found"
+dialog_text = "Please ensure that the save location actually exists."
+
+[connection signal="pressed" from="Margin/VBox/Center/HBox/ExportButton" to="." method="_on_ExportButton_pressed"]
+[connection signal="pressed" from="Margin/VBox/Center/HBox/DoneButton" to="." method="_on_DoneButton_pressed"]

--- a/addons/puzzle_dependencies/views/main_view.gd
+++ b/addons/puzzle_dependencies/views/main_view.gd
@@ -11,12 +11,14 @@ onready var remove_board_button := $Margin/VBox/Toolbar/RemoveBoardButton
 onready var add_thing_button := $Margin/VBox/Toolbar/AddThingButton
 onready var remove_thing_button := $Margin/VBox/Toolbar/RemoveThingButton
 onready var settings_button := $Margin/VBox/Toolbar/SettingsButton
+onready var export_button := $Margin/VBox/Toolbar/ExportButton
 onready var help_button := $Margin/VBox/Toolbar/HelpButton
 onready var update_button := $Margin/VBox/Toolbar/UpdateButton
 onready var board := $Margin/VBox/Board
 onready var edit_board_dialog := $EditBoardDialog
 onready var confirm_remove_board_dialog := $ConfirmRemoveBoardDialog
 onready var settings_dialog := $SettingsDialog
+onready var export_dialog := $ExportDialog
 
 var plugin
 var undo_redo: UndoRedo setget set_undo_redo
@@ -34,6 +36,7 @@ func _ready() -> void:
 	add_thing_button.icon = get_icon("ToolAddNode", "EditorIcons")
 	remove_thing_button.icon = get_icon("Remove", "EditorIcons")
 	settings_button.icon = get_icon("Tools", "EditorIcons")
+	export_button.icon = get_icon("ExternalLink", "EditorIcons")
 	help_button.icon = get_icon("Help", "EditorIcons")
 	
 	# Get boards
@@ -54,10 +57,12 @@ func _ready() -> void:
 	update_button.hide()
 	update_button.add_color_override("font_color", get_color("success_color", "Editor"))
 
+	export_dialog.connect("export_done", self, "_on_export_done")
+
 
 func apply_changes() -> void:
 	save_board()
-	board.apply_changes()	
+	board.apply_changes()
 
 
 ### Setters
@@ -238,3 +243,15 @@ func _on_HelpButton_pressed():
 
 func _on_UpdateButton_pressed():
 	OS.shell_open(update_checker.plugin_url)
+
+
+func _on_ExportButton_pressed():
+	save_board()
+
+	var save_location: String = settings.get_value("export_save_location", "res://")
+
+	export_dialog.export_boards(boards, current_board_id, settings.get_types(), save_location)
+
+
+func _on_export_done(save_location: String):
+	settings.set_value("export_save_location", save_location)

--- a/addons/puzzle_dependencies/views/main_view.tscn
+++ b/addons/puzzle_dependencies/views/main_view.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://addons/puzzle_dependencies/views/main_view.gd" type="Script" id=1]
 [ext_resource path="res://addons/puzzle_dependencies/components/board.tscn" type="PackedScene" id=2]
@@ -6,8 +6,9 @@
 [ext_resource path="res://addons/puzzle_dependencies/components/settings.gd" type="Script" id=4]
 [ext_resource path="res://addons/puzzle_dependencies/views/edit_board_dialog.tscn" type="PackedScene" id=5]
 [ext_resource path="res://addons/puzzle_dependencies/views/settings_dialog.tscn" type="PackedScene" id=6]
+[ext_resource path="res://addons/puzzle_dependencies/views/export_dialog.tscn" type="PackedScene" id=8]
 
-[sub_resource type="Image" id=3]
+[sub_resource type="Image" id=1]
 data = {
 "data": PoolByteArray( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ),
 "format": "LumAlpha8",
@@ -19,7 +20,7 @@ data = {
 [sub_resource type="ImageTexture" id=2]
 flags = 4
 flags = 4
-image = SubResource( 3 )
+image = SubResource( 1 )
 size = Vector2( 16, 16 )
 
 [node name="MainView" type="Control"]
@@ -45,13 +46,13 @@ custom_constants/margin_bottom = 3
 
 [node name="VBox" type="VBoxContainer" parent="Margin"]
 margin_left = 3.0
-margin_right = 1917.0
-margin_bottom = 1077.0
+margin_right = 1021.0
+margin_bottom = 597.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Toolbar" type="HBoxContainer" parent="Margin/VBox"]
-margin_right = 1914.0
+margin_right = 1018.0
 margin_bottom = 24.0
 
 [node name="AddBoardButton" type="ToolButton" parent="Margin/VBox/Toolbar"]
@@ -67,43 +68,46 @@ margin_bottom = 24.0
 
 [node name="BoardsMenu" type="MenuButton" parent="Margin/VBox/Toolbar"]
 margin_left = 40.0
-margin_right = 142.0
+margin_right = 160.0
 margin_bottom = 24.0
-text = "Main board"
+disabled = true
+text = "No boards yet"
 icon = SubResource( 2 )
-items = [ "Main board", SubResource( 2 ), 0, false, false, 0, 0, null, "", false ]
 __meta__ = {
 "_editor_description_": "Pick a board"
 }
 
 [node name="EditBoardButton" type="ToolButton" parent="Margin/VBox/Toolbar"]
-margin_left = 146.0
-margin_right = 174.0
+margin_left = 164.0
+margin_right = 192.0
 margin_bottom = 24.0
 hint_tooltip = "Rename board..."
+disabled = true
 icon = SubResource( 2 )
 __meta__ = {
 "_editor_description_": "Rename the board"
 }
 
 [node name="RemoveBoardButton" type="ToolButton" parent="Margin/VBox/Toolbar"]
-margin_left = 178.0
-margin_right = 206.0
+margin_left = 196.0
+margin_right = 224.0
 margin_bottom = 24.0
 hint_tooltip = "Remove board..."
+disabled = true
 icon = SubResource( 2 )
 
 [node name="Spacer" type="Control" parent="Margin/VBox/Toolbar"]
-margin_left = 210.0
-margin_right = 887.0
+margin_left = 228.0
+margin_right = 432.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
 
 [node name="AddThingButton" type="ToolButton" parent="Margin/VBox/Toolbar"]
-margin_left = 891.0
-margin_right = 983.0
+margin_left = 436.0
+margin_right = 528.0
 margin_bottom = 24.0
 hint_tooltip = "Add a new thing to the board"
+disabled = true
 text = "Add thing"
 icon = SubResource( 2 )
 __meta__ = {
@@ -111,24 +115,25 @@ __meta__ = {
 }
 
 [node name="RemoveThingButton" type="ToolButton" parent="Margin/VBox/Toolbar"]
-margin_left = 987.0
-margin_right = 1015.0
+margin_left = 532.0
+margin_right = 560.0
 margin_bottom = 24.0
 hint_tooltip = "Remove selected thing"
+disabled = true
 icon = SubResource( 2 )
 __meta__ = {
 "_editor_description_": "Remove select thing from the board"
 }
 
 [node name="Spacer2" type="Control" parent="Margin/VBox/Toolbar"]
-margin_left = 1019.0
-margin_right = 1697.0
+margin_left = 564.0
+margin_right = 769.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
 
 [node name="SettingsButton" type="ToolButton" parent="Margin/VBox/Toolbar"]
-margin_left = 1701.0
-margin_right = 1729.0
+margin_left = 773.0
+margin_right = 801.0
 margin_bottom = 24.0
 hint_tooltip = "Settings"
 icon = SubResource( 2 )
@@ -136,14 +141,20 @@ __meta__ = {
 "_editor_description_": "A a new thing to the board"
 }
 
+[node name="ExportButton" type="ToolButton" parent="Margin/VBox/Toolbar"]
+margin_left = 805.0
+margin_right = 833.0
+margin_bottom = 24.0
+icon = SubResource( 2 )
+
 [node name="VSeparator3" type="VSeparator" parent="Margin/VBox/Toolbar"]
-margin_left = 1733.0
-margin_right = 1737.0
+margin_left = 837.0
+margin_right = 841.0
 margin_bottom = 24.0
 
 [node name="HelpButton" type="ToolButton" parent="Margin/VBox/Toolbar"]
-margin_left = 1741.0
-margin_right = 1871.0
+margin_left = 845.0
+margin_right = 975.0
 margin_bottom = 24.0
 hint_tooltip = "View online documentation"
 text = "Documentation"
@@ -151,11 +162,11 @@ icon = SubResource( 2 )
 
 [node name="VersionLabel" type="Label" parent="Margin/VBox/Toolbar"]
 modulate = Color( 1, 1, 1, 0.392157 )
-margin_left = 1875.0
-margin_right = 1914.0
+margin_left = 979.0
+margin_right = 1018.0
 margin_bottom = 24.0
 size_flags_vertical = 1
-text = "v1.0.0"
+text = "v1.0.1"
 valign = 1
 
 [node name="UpdateButton" type="ToolButton" parent="Margin/VBox/Toolbar"]
@@ -170,11 +181,12 @@ __meta__ = {
 }
 
 [node name="Board" parent="Margin/VBox" instance=ExtResource( 2 )]
+visible = false
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_top = 28.0
-margin_right = 1914.0
-margin_bottom = 1077.0
+margin_right = 1018.0
+margin_bottom = 597.0
 _settings = NodePath("../../../Settings")
 
 [node name="EditBoardDialog" parent="." instance=ExtResource( 5 )]
@@ -188,6 +200,8 @@ window_title = "Remove board?"
 [node name="SettingsDialog" parent="." instance=ExtResource( 6 )]
 _settings = NodePath("../Settings")
 
+[node name="ExportDialog" parent="." instance=ExtResource( 8 )]
+
 [connection signal="visibility_changed" from="." to="." method="_on_MainView_visibility_changed"]
 [connection signal="has_update" from="UpdateChecker" to="." method="_on_UpdateChecker_has_update"]
 [connection signal="pressed" from="Margin/VBox/Toolbar/AddBoardButton" to="." method="_on_AddBoardButton_pressed"]
@@ -196,6 +210,7 @@ _settings = NodePath("../Settings")
 [connection signal="pressed" from="Margin/VBox/Toolbar/AddThingButton" to="." method="_on_AddThingButton_pressed"]
 [connection signal="pressed" from="Margin/VBox/Toolbar/RemoveThingButton" to="." method="_on_RemoveThingButton_pressed"]
 [connection signal="pressed" from="Margin/VBox/Toolbar/SettingsButton" to="." method="_on_SettingsButton_pressed"]
+[connection signal="pressed" from="Margin/VBox/Toolbar/ExportButton" to="." method="_on_ExportButton_pressed"]
 [connection signal="pressed" from="Margin/VBox/Toolbar/HelpButton" to="." method="_on_HelpButton_pressed"]
 [connection signal="pressed" from="Margin/VBox/Toolbar/UpdateButton" to="." method="_on_UpdateButton_pressed"]
 [connection signal="updated" from="EditBoardDialog" to="." method="_on_EditBoardDialog_updated"]


### PR DESCRIPTION
This provides for the ability to add various export formats for boards, starting with GraphViz.

The initial implementation can save multiple boards, but at present will save one per file. Future changes are possible.

As I wasn't sure about your feeling for things like abstract classes, you can see that each export "format" is expected to have an implementation of `save_to_format`. These "format" scripts can be attached to a `Node` that is a child of `ExportFormats` in the export dialog scene.

If anything isn't clear, doesn't meet your standards or otherwise needs fixing/adjusting, just let me know and I'm happy to discuss/do.

GraphViz is extremely flexible and can render graphs to various formats (PNG, SVG, etc.) based on text input. When exporting to GraphViz via the functionality in this PR, a `.dot` file results and can then be used as necessary by a GraphViz installation. This makes it perfect for sharing with folks who might not necessarily be using Godot.

Even if this PR isn't picked up, thank you for your consideration. Your Puzzle Dependencies addons is a great addition to any adventure gamedev's toolbox!